### PR TITLE
db and dt were reversed and did not work

### DIFF
--- a/examples/server_side/scripts/ssp.class.php
+++ b/examples/server_side/scripts/ssp.class.php
@@ -43,10 +43,10 @@ class SSP {
 
 				// Is there a formatter?
 				if ( isset( $column['formatter'] ) ) {
-					$row[ $column['dt'] ] = $column['formatter']( $data[$i][ $column['db'] ], $data[$i] );
+					$row[ $column['db'] ] = $column['formatter']( $data[$i][ $column['dt'] ], $data[$i] );
 				}
 				else {
-					$row[ $column['dt'] ] = $data[$i][ $columns[$j]['db'] ];
+					$row[ $column['db'] ] = $data[$i][ $column['dt'] ];
 				}
 			}
 


### PR DESCRIPTION
on rows 46 and 49 $column['dt'] and $column['db'] were reversed and did not display anything correctly.


yeah, I accept having this under the MIT license